### PR TITLE
Add phase-aware layout tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,30 @@ npm run deploy
 npm run deploy-win
 ```
 
+For more details on running or deploying the modded version, see [SELF_HOST.md](SELF_HOST.md).
+## Phase Visualizer
+Add a small progress indicator, accessible via a new tab in the Message Queue. Initialize the visualizer after the message queue:
+
+```javascript
+import { initPhaseVisualizer } from './src/phaseVisualizer.js';
+initPhaseVisualizer('phaseVisualizer');
+```
+
+Trigger `recordEvent` whenever buttons, milestones, tabs or subheaders are unlocked.
+
+The current phase value is stored in your save data automatically. Loading an existing
+game will restore the phase visualizer progress.
+
+## Layout Tab
+A new **Layout** tab appears next to Settings. It opens a large canvas displaying a
+grid of buildings colored by sector. The view can be dragged with the mouse and
+zoomed using the scroll wheel. As your phase increases, the subtitle beneath the
+map updates to reflect the current operational focus, such as Planetary or
+Interplanetary activities. Citizens and soldiers are shown as white and red
+pixels respectively. Use the **Key** button below the canvas to toggle a legend
+explaining each color.
+
+
 ## Docker
 If you already have a Docker environment set up and want to run an evolve server using Docker, you can execute the following command to build a Docker image for the evolve server.
 

--- a/SELF_HOST.md
+++ b/SELF_HOST.md
@@ -1,0 +1,18 @@
+# Self Hosting the Modded Game
+
+This repository can be served locally or from GitHub Pages. To play the modded version locally you will need Node.js installed.
+
+```bash
+npm install
+npm run serve
+```
+
+This starts a local web server at `http://localhost:4400`.
+
+To deploy to GitHub Pages you can run:
+
+```bash
+npm run deploy
+```
+
+The command copies the needed game files into a `dist/` directory and publishes it to the `gh-pages` branch. Once the branch is published you can enable GitHub Pages in your repository settings and the game will be available from `https://<your username>.github.io/<repository>/`.

--- a/src/achieve.js
+++ b/src/achieve.js
@@ -4,6 +4,7 @@ import { races, genus_def } from './races.js';
 import { actions } from './actions.js';
 import { universe_affixes, universe_types, piracy } from './space.js';
 import { monsters } from './portal.js';
+import { recordEvent } from './phaseVisualizer.js';
 import { loc } from './locale.js'
 
 const achieve_list = {
@@ -346,11 +347,15 @@ export function unlockAchieve(achievement,small,rank,universe){
     }
     if ((global.race.universe === 'micro' && small === true) || (global.race.universe !== 'micro' && small !== true)){
         if (global.stats.achieve[achievement] && global.stats.achieve[achievement].l < rank){
+            if (!global.settings.showAchieve) {
+                recordEvent('tabUnlocked','stats');
+            }
             global.settings.showAchieve = true;
             global.stats.achieve[achievement].l = rank;
             messageQueue(loc(upgrade ? 'achieve_unlock_achieve_upgrade' : 'achieve_unlock_achieve', [achievements[achievement].name] ),'special',false,['achievements']);
             redraw = true;
             unlock = true;
+            recordEvent('milestoneReached', achievement);
         }
     }
     if (global.stats.achieve[achievement] && universe !== 'l'){
@@ -386,11 +391,15 @@ export function unlockFeat(feat,small,rank){
     }
     if (!global.stats.feat[feat] || (global.stats.feat[feat] && global.stats.feat[feat] < rank)){
         let upgrade = global.stats.feat[feat] ? true : false;
+        if (!global.settings.showAchieve) {
+            recordEvent('tabUnlocked','stats');
+        }
         global.settings.showAchieve = true;
         global.stats.feat[feat] = rank;
         messageQueue(loc(upgrade ? 'feat_upgraded' : 'feat_unlocked', [feats[feat].name] ),'special',false,['achievements']);
         drawPerks();
         drawAchieve();
+        recordEvent('milestoneReached', feat);
         return true;
     }
     return false;

--- a/src/evolve.less
+++ b/src/evolve.less
@@ -5450,3 +5450,7 @@ div.bigbang {
     position: absolute;
     top: 1rem;
 }
+/* Layout tab */
+.layoutKey{margin-top:0.5rem;font-size:0.9rem;}
+.layoutKey .keyBox{display:inline-block;width:12px;height:12px;margin-right:4px;vertical-align:middle;}
+

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import { clearSpyopDrag } from './governor.js';
 import { defineIndustry, setPowerGrid, gridDefs, clearGrids } from './industry.js';
 import { defineGovernment, defineGarrison, buildGarrison, commisionGarrison, foreignGov } from './civics.js';
 import { races, shapeShift, renderPsychicPowers, renderSupernatural } from './races.js';
+import { recordEvent } from './phaseVisualizer.js';
 import { drawEvolution, drawCity, drawTech, resQueue, clearResDrag } from './actions.js';
 import { renderSpace, ascendLab, terraformLab } from './space.js';
 import { renderFortress, buildFortress, drawMechLab, clearMechDrag, drawHellObservations } from './portal.js';
@@ -316,6 +317,7 @@ export function initTabs(){
 }
 
 export function loadTab(tab){
+    recordEvent('tabUnlocked', tab);
     if (!global.settings.tabLoad){
         clearResDrag();
         clearGrids();
@@ -937,29 +939,50 @@ export function index(){
             <div class="power"><span id="powerStatus" class="has-text-warning" v-show="city.powered"><span>MW</span> <span id="powerMeter" class="meter">{{ city.power | replicate | approx }}</span></span></div>
         </div>
         <div id="sideQueue">
-            <div id="buildQueue" class="bldQueue standardqueuestyle has-text-info" v-show="display"></div>
-            <div id="msgQueue" class="msgQueue vscroll has-text-info" aria-live="polite">
-                <div id="msgQueueHeader">
-                    <h2 class="has-text-success">${loc('message_log')}</h2>
-                    <span class="special" role="button" title="message queue options" @click="trigModal">
-                        <svg version="1.1" x="0px" y="0px" width="12px" height="12px" viewBox="340 140 280 279.416" enable-background="new 340 140 280 279.416" xml:space="preserve">
-                            <path class="gear" d="M620,305.666v-51.333l-31.5-5.25c-2.333-8.75-5.833-16.917-9.917-23.917L597.25,199.5l-36.167-36.75l-26.25,18.083
-                            c-7.583-4.083-15.75-7.583-23.916-9.917L505.667,140h-51.334l-5.25,31.5c-8.75,2.333-16.333,5.833-23.916,9.916L399.5,163.333
-                            L362.75,199.5l18.667,25.666c-4.083,7.584-7.583,15.75-9.917,24.5l-31.5,4.667v51.333l31.5,5.25
-                            c2.333,8.75,5.833,16.334,9.917,23.917l-18.667,26.25l36.167,36.167l26.25-18.667c7.583,4.083,15.75,7.583,24.5,9.917l5.25,30.916
-                            h51.333l5.25-31.5c8.167-2.333,16.333-5.833,23.917-9.916l26.25,18.666l36.166-36.166l-18.666-26.25
-                            c4.083-7.584,7.583-15.167,9.916-23.917L620,305.666z M480,333.666c-29.75,0-53.667-23.916-53.667-53.666s24.5-53.667,53.667-53.667
-                            S533.667,250.25,533.667,280S509.75,333.666,480,333.666z"/>
-                        </svg>
-                    </span>
-                    <span role="button" class="zero has-text-advanced" @click="clearLog(m.view)">${loc('message_log_clear')}</span>
-                    <span role="button" class="zero has-text-advanced" @click="clearLog()">${loc('message_log_clear_all')}</span>
-                </div>
-                <h2 class="is-sr-only">${loc('message_filters')}</h2>
-                <div id="msgQueueFilters" class="hscroll msgQueueFilters"></div>
-                <h2 class="is-sr-only">${loc('messages')}</h2>
-                <div id="msgQueueLog" aria-live="polite"></div>
-            </div>
+            <b-tabs id="queueTabs" class="resTabs" v-model="s.queueTabs" :animated="s.animated">
+                <b-tab-item id="buildTab">
+                    <template slot="header">
+                        <h2 class="is-sr-only">${loc('tab_build_queue')}</h2>
+                        <span aria-hidden="true">${loc('tab_build_queue')}</span>
+                    </template>
+                    <div id="buildQueue" class="bldQueue standardqueuestyle has-text-info" v-show="display"></div>
+                </b-tab-item>
+                <b-tab-item id="msgTab">
+                    <template slot="header">
+                        <h2 class="is-sr-only">${loc('message_log')}</h2>
+                        <span aria-hidden="true">${loc('message_log')}</span>
+                    </template>
+                    <div id="msgQueue" class="msgQueue vscroll has-text-info" aria-live="polite">
+                        <div id="msgQueueHeader">
+                            <h2 class="has-text-success">${loc('message_log')}</h2>
+                            <span class="special" role="button" title="message queue options" @click="trigModal">
+                                <svg version="1.1" x="0px" y="0px" width="12px" height="12px" viewBox="340 140 280 279.416" enable-background="new 340 140 280 279.416" xml:space="preserve">
+                                    <path class="gear" d="M620,305.666v-51.333l-31.5-5.25c-2.333-8.75-5.833-16.917-9.917-23.917L597.25,199.5l-36.167-36.75l-26.25,18.083
+                                    c-7.583-4.083-15.75-7.583-23.916-9.917L505.667,140h-51.334l-5.25,31.5c-8.75,2.333-16.333,5.833-23.916,9.916L399.5,163.333
+                                    L362.75,199.5l18.667,25.666c-4.083,7.584-7.583,15.75-9.917,24.5l-31.5,4.667v51.333l31.5,5.25
+                                    c2.333,8.75,5.833,16.334,9.917,23.917l-18.667,26.25l36.167,36.167l26.25-18.667c7.583,4.083,15.75,7.583,24.5,9.917l5.25,30.916
+                                    h51.333l5.25-31.5c8.167-2.333,16.333-5.833,23.917-9.916l26.25,18.666l36.166-36.166l-18.666-26.25
+                                    c4.083-7.584,7.583-15.167,9.916-23.917L620,305.666z M480,333.666c-29.75,0-53.667-23.916-53.667-53.666s24.5-53.667,53.667-53.667
+                                    S533.667,250.25,533.667,280S509.75,333.666,480,333.666z"/>
+                                </svg>
+                            </span>
+                            <span role="button" class="zero has-text-advanced" @click="clearLog(m.view)">${loc('message_log_clear')}</span>
+                            <span role="button" class="zero has-text-advanced" @click="clearLog()">${loc('message_log_clear_all')}</span>
+                        </div>
+                        <h2 class="is-sr-only">${loc('message_filters')}</h2>
+                        <div id="msgQueueFilters" class="hscroll msgQueueFilters"></div>
+                        <h2 class="is-sr-only">${loc('messages')}</h2>
+                        <div id="msgQueueLog" aria-live="polite"></div>
+                    </div>
+                </b-tab-item>
+                <b-tab-item id="phaseTab">
+                    <template slot="header">
+                        <h2 class="is-sr-only">Phase Visualizer</h2>
+                        <span aria-hidden="true">Phase</span>
+                    </template>
+                    <pre id="phaseVisualizer" class="msgQueue vscroll"></pre>
+                </b-tab-item>
+            </b-tabs>
         </div>
         <div id="resources" class="resources vscroll"><h2 class="is-sr-only">${loc('tab_resources')}</h2></div>
     </div>`);
@@ -967,6 +990,10 @@ export function index(){
         $(`#msgQueueFilters`).append(`
             <span id="msgQueueFilter-${filter}" class="${filter === 'all' ? 'is-active' : ''}" aria-disabled="${filter === 'all' ? 'true' : 'false'}" @click="swapFilter('${filter}')" v-show="s.${filter}.vis" role="button">${loc('message_log_' + filter)}</span>
         `);
+    });
+    vBind({
+        el: `#sideQueue`,
+        data: { s: global.settings }
     });
     vBind({
         el: `#msgQueue`,
@@ -1468,6 +1495,24 @@ export function index(){
 
     tabs.append(settings);
 
+    // Layout Tab
+    let layoutTab = $(`<b-tab-item id="layoutTab" class="layout sticky">
+        <template slot="header">Layout</template>
+        <div id="layoutContainer">
+            <h2 id="layoutSubtitle"></h2>
+            <canvas id="layoutCanvas" width="600" height="400" class="layoutCanvas"></canvas>
+            <button id="layoutKeyToggle" class="button">Key</button>
+            <div id="layoutKey" style="display:none" class="layoutKey">
+                <div><span class="keyBox" style="background:#3498db"></span> Residential</div>
+                <div><span class="keyBox" style="background:#e67e22"></span> Industrial</div>
+                <div><span class="keyBox" style="background:#2ecc71"></span> Civic</div>
+                <div><span class="keyBox" style="background:#ffffff"></span> Citizens</div>
+                <div><span class="keyBox" style="background:#ff0000"></span> Soldiers</div>
+            </div>
+        </div>
+    </b-tab-item>`);
+    tabs.append(layoutTab);
+
     // (Hidden Last Tab) Hell Observation Tab
     let observe = $(`<b-tab-item disabled>
         <template slot="header"></template>
@@ -1502,4 +1547,10 @@ export function index(){
             </span>
         </div>
     `);
+
+    document.addEventListener('DOMNodeInserted', function(e){
+        if (e.target && e.target.classList && e.target.classList.contains('divider')) {
+            recordEvent('subheaderAdded', e.target.textContent.trim());
+        }
+    });
 }

--- a/src/layout.js
+++ b/src/layout.js
@@ -1,0 +1,121 @@
+import { global } from './vars.js';
+import { currentPhase, onPhaseChange } from './phaseVisualizer.js';
+
+let canvas, ctx, subtitle, keyToggle, keyBox;
+let zoom = 1;
+let offsetX = 0;
+let offsetY = 0;
+let dragging = false;
+let startX = 0;
+let startY = 0;
+
+export function initLayoutVisualizer(canvasId, subtitleId) {
+    canvas = document.getElementById(canvasId);
+    subtitle = document.getElementById(subtitleId);
+    keyToggle = document.getElementById('layoutKeyToggle');
+    keyBox = document.getElementById('layoutKey');
+    if (!canvas) return;
+    ctx = canvas.getContext('2d');
+    canvas.addEventListener('wheel', onWheel);
+    canvas.addEventListener('mousedown', startDrag);
+    canvas.addEventListener('mousemove', drag);
+    canvas.addEventListener('mouseup', endDrag);
+    canvas.addEventListener('mouseleave', endDrag);
+    if (keyToggle && keyBox) {
+        keyToggle.addEventListener('click', () => {
+            keyBox.style.display = keyBox.style.display === 'none' ? 'block' : 'none';
+        });
+    }
+    onPhaseChange(updateSubtitle);
+    updateSubtitle(currentPhase());
+    draw();
+}
+
+function onWheel(e) {
+    e.preventDefault();
+    zoom += e.deltaY > 0 ? -0.1 : 0.1;
+    zoom = Math.max(0.2, Math.min(zoom, 5));
+    draw();
+}
+
+function startDrag(e){
+    dragging = true;
+    startX = e.clientX;
+    startY = e.clientY;
+}
+
+function drag(e){
+    if(!dragging) return;
+    offsetX += (e.clientX - startX);
+    offsetY += (e.clientY - startY);
+    startX = e.clientX;
+    startY = e.clientY;
+    draw();
+}
+
+function endDrag(){
+    dragging = false;
+}
+
+function gatherBuildings(){
+    const counts = { residential:0, industrial:0, civic:0 };
+    if (!global.city) return counts;
+    Object.keys(global.city).forEach(k=>{
+        const count = global.city[k] && global.city[k].count ? global.city[k].count : 0;
+        if (/house|cottage|apartment/i.test(k)) counts.residential += count;
+        else if (/factory|foundry|mill|forge/i.test(k)) counts.industrial += count;
+        else counts.civic += count;
+    });
+    return counts;
+}
+
+function gatherPopulation(){
+    const citizens = global.resource[global.race?.species]?.amount || 0;
+    const soldiers = global.civic?.garrison?.workers || 0;
+    return { citizens, soldiers };
+}
+
+function draw(){
+    if(!ctx) return;
+    ctx.clearRect(0,0,canvas.width,canvas.height);
+    ctx.save();
+    ctx.translate(offsetX, offsetY);
+    ctx.scale(zoom, zoom);
+    const cell = 20;
+    const counts = gatherBuildings();
+    const pop = gatherPopulation();
+    const cells = [
+        { count: counts.residential, color: '#3498db' },
+        { count: counts.industrial, color: '#e67e22' },
+        { count: counts.civic, color: '#2ecc71' }
+    ];
+    let x = 0; let y = 0; const maxX = Math.floor(canvas.width / cell / zoom);
+    cells.forEach(c=>{
+        for(let i=0;i<c.count;i++){
+            ctx.fillStyle = c.color;
+            ctx.fillRect(x*cell, y*cell, cell-2, cell-2);
+            x++;
+            if(x >= maxX){ x = 0; y++; }
+        }
+    });
+    const maxDots = 200;
+    for(let i=0;i<Math.min(pop.citizens,maxDots);i++){
+        ctx.fillStyle = '#ffffff';
+        ctx.fillRect(Math.random()*canvas.width/zoom, Math.random()*canvas.height/zoom, 2, 2);
+    }
+    for(let i=0;i<Math.min(pop.soldiers,maxDots);i++){
+        ctx.fillStyle = '#ff0000';
+        ctx.fillRect(Math.random()*canvas.width/zoom, Math.random()*canvas.height/zoom, 2, 2);
+    }
+    ctx.restore();
+}
+
+export function updateSubtitle(phase){
+    if(!subtitle) return;
+    if(phase >= 5){
+        subtitle.textContent = 'Interplanetary Operations';
+    } else {
+        subtitle.textContent = 'Planetary Operations';
+    }
+    draw();
+}

--- a/src/main.js
+++ b/src/main.js
@@ -8,6 +8,8 @@ import { defineJobs, job_desc, loadFoundry, farmerValue, jobName, jobScale, work
 import { defineIndustry, f_rate, manaCost, setPowerGrid, gridEnabled, gridDefs, nf_resources, replicator, luxGoodPrice, smelterUnlocked, smelterFuelConfig } from './industry.js';
 import { checkControlling, garrisonSize, armyRating, govTitle, govCivics, govEffect, weaponTechModifer } from './civics.js';
 import { actions, updateDesc, checkTechRequirements, drawEvolution, BHStorageMulti, storageMultipler, checkAffordable, checkPowerRequirements, drawCity, drawTech, gainTech, housingLabel, updateQueueNames, wardenLabel, planetGeology, resQueue, bank_vault, start_cataclysm, orbitDecayed, postBuild, skipRequirement, structName, templeCount, initStruct, casino_vault, casinoEarn, doCallbacks, cLabels } from './actions.js';
+import { initPhaseVisualizer, recordEvent } from './phaseVisualizer.js';
+import { initLayoutVisualizer } from './layout.js';
 import { renderSpace, convertSpaceSector, fuel_adjust, int_fuel_adjust, zigguratBonus, planetName, genPlanets, setUniverse, universe_types, gatewayStorage, piracy, spaceTech, universe_affixes, galaxyRegions, gatewayArmada, galaxy_ship_types } from './space.js';
 import { renderFortress, bloodwar, soulForgeSoldiers, hellSupression, genSpireFloor, mechRating, mechCollect, updateMechbay, hellguard, buildMechQueue, mechCost } from './portal.js';
 import { asphodelResist, mechStationEffect, renderEdenic } from './edenic.js';
@@ -177,6 +179,8 @@ else {
 }
 
 initMessageQueue();
+initPhaseVisualizer('phaseVisualizer');
+initLayoutVisualizer('layoutCanvas','layoutSubtitle');
 
 if (global.lastMsg){
     Object.keys(global.lastMsg).forEach(function (tag){

--- a/src/phaseVisualizer.js
+++ b/src/phaseVisualizer.js
@@ -1,0 +1,48 @@
+import { global } from './vars.js';
+
+let container = null;
+const unlockedTabs = new Set();
+const phaseCallbacks = [];
+
+function phaseVal() {
+    if (global.phase === undefined) {
+        global.phase = 0;
+    }
+    return global.phase;
+}
+
+function draw() {
+    if (!container) return;
+    const total = 10;
+    const phase = phaseVal();
+    const filled = Math.min(total, phase % (total + 1));
+    const bar = '[' + '#'.repeat(filled) + '-'.repeat(total - filled) + ']';
+    container.textContent = `Phase ${phase}\n${bar}`;
+}
+
+export function initPhaseVisualizer(id) {
+    container = document.getElementById(id);
+    draw();
+}
+
+export function recordEvent(eventType, detail) {
+    if (eventType === 'tabUnlocked') {
+        if (detail && unlockedTabs.has(detail)) return;
+        if (detail) unlockedTabs.add(detail);
+        global.phase = phaseVal() + 1;
+    } else if (['buttonUnlocked','milestoneReached','subheaderAdded'].includes(eventType)) {
+        global.phase = phaseVal() + 1;
+    }
+    phaseCallbacks.forEach(fn => {
+        try { fn(global.phase); } catch (e) {}
+    });
+    draw();
+}
+
+export function currentPhase() {
+    return phaseVal();
+}
+
+export function onPhaseChange(fn){
+    phaseCallbacks.push(fn);
+}

--- a/src/resetFX.js
+++ b/src/resetFX.js
@@ -1,0 +1,75 @@
+export function playBioseedFx(callback){
+    const style = document.createElement('style');
+    style.textContent = `
+@keyframes rocketFlight {
+    from { transform: translate(0,0) scale(1); }
+    to { transform: translate(90vw, -40vh) scale(0.3); }
+}`;
+    document.head.appendChild(style);
+    const overlay = document.createElement('div');
+    overlay.style.position = 'fixed';
+    overlay.style.top = 0;
+    overlay.style.left = 0;
+    overlay.style.width = '100%';
+    overlay.style.height = '100%';
+    overlay.style.background = 'white';
+    overlay.style.zIndex = 9999;
+    overlay.style.opacity = 0;
+    overlay.style.transition = 'opacity 0.25s';
+    document.body.appendChild(overlay);
+    requestAnimationFrame(() => { overlay.style.opacity = 1; });
+    setTimeout(() => { overlay.style.opacity = 0; }, 300);
+    setTimeout(() => {
+        overlay.style.background = 'transparent';
+        const pre = document.createElement('pre');
+        pre.textContent = '  /\\\n /  \\\n|NASA|\n/____\\';
+        pre.style.position = 'absolute';
+        pre.style.left = '0';
+        pre.style.top = '0';
+        pre.style.fontFamily = 'monospace';
+        pre.style.fontSize = '24px';
+        pre.style.animation = 'rocketFlight 2s linear forwards';
+        overlay.appendChild(pre);
+        overlay.style.opacity = 1;
+        setTimeout(() => {
+            document.body.removeChild(overlay);
+            style.remove();
+            if (callback) callback();
+        }, 2000);
+    }, 500);
+}
+
+export function playBigBangFx(callback){
+    const style = document.createElement('style');
+    style.textContent = `
+@keyframes galaxyCollapse {
+    from { transform: translate(-50%, -50%) scale(1) rotate(0deg); opacity:1; }
+    to { transform: translate(-50%, -50%) scale(0) rotate(720deg); opacity:0; }
+}`;
+    document.head.appendChild(style);
+    const overlay = document.createElement('div');
+    overlay.style.position = 'fixed';
+    overlay.style.top = 0;
+    overlay.style.left = 0;
+    overlay.style.width = '100%';
+    overlay.style.height = '100%';
+    overlay.style.background = 'black';
+    overlay.style.zIndex = 9999;
+    overlay.style.display = 'flex';
+    overlay.style.alignItems = 'center';
+    overlay.style.justifyContent = 'center';
+    document.body.appendChild(overlay);
+    const pre = document.createElement('pre');
+    pre.style.color = 'white';
+    pre.style.fontFamily = 'monospace';
+    pre.style.fontSize = '24px';
+    pre.style.whiteSpace = 'pre';
+    pre.textContent = '  *    .     *\n    .  *  .\n*  .  *  .  *\n    .    .\n';
+    pre.style.animation = 'galaxyCollapse 2.5s forwards';
+    overlay.appendChild(pre);
+    setTimeout(() => {
+        document.body.removeChild(overlay);
+        style.remove();
+        if (callback) callback();
+    }, 2500);
+}

--- a/src/resets.js
+++ b/src/resets.js
@@ -1,5 +1,6 @@
 import { global, save, seededRandom, webWorker, clearSavedMessages, clearStates } from './vars.js';
 import { tagEvent, calcPrestige, updateResetStats } from './functions.js';
+import { playBioseedFx, playBigBangFx } from './resetFX.js';
 import { races, planetTraits } from './races.js';
 import { unlockAchieve, unlockFeat, checkAchievements, universeAffix, alevel } from './achieve.js';
 
@@ -220,7 +221,7 @@ export function bioseed(){
     });
 
     save.setItem('evolved',LZString.compressToUTF16(JSON.stringify(global)));
-    window.location.reload();
+    playBioseedFx(() => window.location.reload());
 }
 
 // Cataclysm
@@ -425,7 +426,7 @@ export function big_bang(){
     });
 
     save.setItem('evolved',LZString.compressToUTF16(JSON.stringify(global)));
-    window.location.reload();
+    playBigBangFx(() => window.location.reload());
 }
 
 export function vacuumCollapse(){

--- a/src/resources.js
+++ b/src/resources.js
@@ -8,6 +8,7 @@ import { syndicate } from './truepath.js';
 import { govActive, defineGovernor } from './governor.js';
 import { govEffect } from './civics.js';
 import { highPopAdjust, production, teamster } from './prod.js';
+import { recordEvent } from './phaseVisualizer.js';
 import { loc } from './locale.js';
 
 export const resource_values = {
@@ -2581,6 +2582,9 @@ function unlockStorage(){
     }
 
     // Enable display for resource tab and storage subtab
+    if (!global.settings.showStorage) {
+        recordEvent('tabUnlocked','storage');
+    }
     global.settings.showResources = true;
     global.settings.showStorage = true;
 
@@ -2603,6 +2607,7 @@ export function unlockCrates(){
 
         // Unlock the storage tab
         unlockStorage();
+        recordEvent('buttonUnlocked','crates');
     }
 }
 
@@ -2618,6 +2623,7 @@ export function unlockContainers(){
 
         // Unlock the storage tab
         unlockStorage();
+        recordEvent('buttonUnlocked','containers');
     }
 }
 

--- a/src/vars.js
+++ b/src/vars.js
@@ -2,6 +2,7 @@ export var save = window.localStorage;
 export var global = {
     seed: 1,
     warseed: 1,
+    phase: 0,
     resource: {},
     evolution: {},
     tech: {},
@@ -89,6 +90,9 @@ export function seededRandom(min, max, alt, useSeed) {
         }
         else {
             newGameData();
+        }
+        if (global.phase === undefined) {
+            global.phase = 0;
         }
     }
     else {
@@ -2010,6 +2014,7 @@ function newGameData(){
     global['race'] = { species : 'protoplasm', gods: 'none', old_gods: 'none', seeded: false };
     global['seed'] = Math.rand(0,10000);
     global['warseed'] = Math.rand(0,10000);
+    global['phase'] = 0;
     global['new'] = true;
 }
 
@@ -2323,7 +2328,7 @@ function setRegionStates(reset){
 
     // Tab Indexes
     [
-        'civTabs','govTabs','govTabs2','hellTabs','resTabs','spaceTabs','marketTabs','statsTabs'
+        'civTabs','govTabs','govTabs2','hellTabs','resTabs','spaceTabs','marketTabs','statsTabs','queueTabs'
     ].forEach(function(k){
         if (!global.settings.hasOwnProperty(k) || reset){
             global.settings[k] = 0;


### PR DESCRIPTION
## Summary
- add Layout tab for a zoomable map next to Settings
- publish a layout visualizer module for dragging/zooming
- update phase visualizer to broadcast phase changes
- initialise layout visualizer with the game
- document the new tab in the README
- show citizens and soldiers in different colors
- include a toggleable map key explaining colors

## Testing
- `npm run build` *(fails: Cannot find module 'esbuild')*

------
https://chatgpt.com/codex/tasks/task_e_685a1388046883289a3782115130bf15