### PR TITLE
Add start.bat for easy launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ npm run deploy
 npm run deploy-win
 ```
 
+For an assisted start on Windows run `start.bat`. It installs dependencies and
+launches the local server automatically.
+
 For more details on running or deploying the modded version, see [SELF_HOST.md](SELF_HOST.md).
 ## Phase Visualizer
 Add a small progress indicator, accessible via a new tab in the Message Queue. Initialize the visualizer after the message queue:

--- a/SELF_HOST.md
+++ b/SELF_HOST.md
@@ -2,6 +2,9 @@
 
 This repository can be served locally or from GitHub Pages. To play the modded version locally you will need Node.js installed.
 
+On Windows you can simply run `start.bat` located in the project root. The script installs the required dependencies and then launches the local server for you.
+If you'd rather run the commands yourself, use the following:
+
 ```bash
 npm install
 npm run serve

--- a/start.bat
+++ b/start.bat
@@ -1,0 +1,7 @@
+@echo off
+REM Assisted start script for Windows
+REM Installs dependencies and launches the local server
+npm install
+npm run serve
+pause
+


### PR DESCRIPTION
## Summary
- add a simple Windows batch file for launching the local server
- mention `start.bat` in README
- document `start.bat` usage at the top of SELF_HOST.md

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6861deb77e588328a293b9ae94316f2b